### PR TITLE
Changed the README instructions to point to the correct Git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See the [Reference Manual](https://stetre.github.io/moonnuklear/doc/index.html).
 Setup the build environment as described [here](https://github.com/stetre/moonlibs), then:
 
 ```sh
-$ git clone https://github.com/stetre/moonglfw
+$ git clone https://github.com/stetre/moonnuklear
 $ cd moonnuklear
 moonnuklear$ make
 moonnuklear$ make install # or 'sudo make install' (Ubuntu and MacOS)


### PR DESCRIPTION
I just tried to install your library following the instructions but ended up installing `moonglfw` by mistake. I suppose that is my own fault by mindlessly copy pasting stuff into my terminal but maybe this change can help other people too. 
BTW awesome work. 